### PR TITLE
Guarantee that c# auth callbacks are async to core

### DIFF
--- a/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
+++ b/src/csharp/Grpc.Core/Internal/NativeMetadataCredentialsPlugin.cs
@@ -61,12 +61,9 @@ namespace Grpc.Core.Internal
 
             try
             {
-                var context = new AuthInterceptorContext(Marshal.PtrToStringAnsi(serviceUrlPtr),
-                                                         Marshal.PtrToStringAnsi(methodNamePtr));
-                // Don't await, we are in a native callback and need to return.
-                #pragma warning disable 4014
-                GetMetadataAsync(context, callbackPtr, userDataPtr);
-                #pragma warning restore 4014
+                var context = new AuthInterceptorContext(Marshal.PtrToStringAnsi(serviceUrlPtr), Marshal.PtrToStringAnsi(methodNamePtr));
+                // Make a guarantee that credentials_notify_from_plugin is invoked async to be compliant with c-core API.
+                ThreadPool.QueueUserWorkItem(async (stateInfo) => await GetMetadataAsync(context, callbackPtr, userDataPtr));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Seeing the added tests here segfault every time before the change to `NativeMetadataCredentialsPlugin.cs` here - it looks like an existing bug in c# with composite credentials.
(in the case where the async auth interceptor callback is inlineable, we end up hitting a use-after-free in the composite credentials core code due to notifying completion of auth callback synchronously. use in https://github.com/grpc/grpc/blob/master/src/core/lib/security/credentials/composite/composite_credentials.c#L103 and earlier free in https://github.com/grpc/grpc/blob/master/src/core/lib/security/credentials/composite/composite_credentials.c#L72).
