### PR TITLE
Temporary fixes for LB Stuff

### DIFF
--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -1705,7 +1705,7 @@ grpc_error_handle ClientChannel::DoPingLocked(grpc_transport_op* op) {
       result.result,
       // Complete pick.
       [op](const LoadBalancingPolicy::PickResult::Complete& complete_pick)
-          ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::work_serializer_) {
+          ABSL_NO_THREAD_SAFETY_ANALYSIS {
             SubchannelWrapper* subchannel =
                 static_cast<SubchannelWrapper*>(complete_pick.subchannel.get());
             ConnectedSubchannel* connected_subchannel =

--- a/src/core/ext/filters/client_channel/client_channel.cc
+++ b/src/core/ext/filters/client_channel/client_channel.cc
@@ -3006,79 +3006,79 @@ bool ClientChannel::LoadBalancedCall::PickSubchannelLocked(
   return MatchMutable(
       &result.result,
       // CompletePick
-      [this](LoadBalancingPolicy::PickResult::Complete* complete_pick)
-          ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::data_plane_mu_) {
-            if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
-              gpr_log(GPR_INFO,
-                      "chand=%p lb_call=%p: LB pick succeeded: subchannel=%p",
-                      chand_, this, complete_pick->subchannel.get());
-            }
-            GPR_ASSERT(complete_pick->subchannel != nullptr);
-            // Grab a ref to the connected subchannel while we're still
-            // holding the data plane mutex.
-            connected_subchannel_ = chand_->GetConnectedSubchannelInDataPlane(
-                complete_pick->subchannel.get());
-            GPR_ASSERT(connected_subchannel_ != nullptr);
-            lb_recv_trailing_metadata_ready_ =
-                std::move(complete_pick->recv_trailing_metadata_ready);
-            MaybeRemoveCallFromLbQueuedCallsLocked();
-            return true;
-          },
+      [this](LoadBalancingPolicy::PickResult::Complete* complete_pick) {
+        chand_->data_plane_mu_.AssertHeld();
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+          gpr_log(GPR_INFO,
+                  "chand=%p lb_call=%p: LB pick succeeded: subchannel=%p",
+                  chand_, this, complete_pick->subchannel.get());
+        }
+        GPR_ASSERT(complete_pick->subchannel != nullptr);
+        // Grab a ref to the connected subchannel while we're still
+        // holding the data plane mutex.
+        connected_subchannel_ = chand_->GetConnectedSubchannelInDataPlane(
+            complete_pick->subchannel.get());
+        GPR_ASSERT(connected_subchannel_ != nullptr);
+        lb_recv_trailing_metadata_ready_ =
+            std::move(complete_pick->recv_trailing_metadata_ready);
+        MaybeRemoveCallFromLbQueuedCallsLocked();
+        return true;
+      },
       // QueuePick
-      [this](LoadBalancingPolicy::PickResult::Queue* /*queue_pick*/)
-          ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::data_plane_mu_) {
-            if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
-              gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick queued", chand_,
-                      this);
-            }
-            MaybeAddCallToLbQueuedCallsLocked();
-            return false;
-          },
+      [this](LoadBalancingPolicy::PickResult::Queue* /*queue_pick*/) {
+        chand_->data_plane_mu_.AssertHeld();
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+          gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick queued", chand_,
+                  this);
+        }
+        MaybeAddCallToLbQueuedCallsLocked();
+        return false;
+      },
       // FailPick
       [this, send_initial_metadata_flags,
-       &error](LoadBalancingPolicy::PickResult::Fail* fail_pick)
-          ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::data_plane_mu_) {
-            if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
-              gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick failed: %s",
-                      chand_, this, fail_pick->status.ToString().c_str());
-            }
-            // If we're shutting down, fail all RPCs.
-            grpc_error_handle disconnect_error = chand_->disconnect_error();
-            if (disconnect_error != GRPC_ERROR_NONE) {
-              MaybeRemoveCallFromLbQueuedCallsLocked();
-              *error = GRPC_ERROR_REF(disconnect_error);
-              return true;
-            }
-            // If wait_for_ready is false, then the error indicates the RPC
-            // attempt's final status.
-            if ((send_initial_metadata_flags &
-                 GRPC_INITIAL_METADATA_WAIT_FOR_READY) == 0) {
-              grpc_error_handle lb_error =
-                  absl_status_to_grpc_error(fail_pick->status);
-              *error = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
-                  "Failed to pick subchannel", &lb_error, 1);
-              GRPC_ERROR_UNREF(lb_error);
-              MaybeRemoveCallFromLbQueuedCallsLocked();
-              return true;
-            }
-            // If wait_for_ready is true, then queue to retry when we get a new
-            // picker.
-            MaybeAddCallToLbQueuedCallsLocked();
-            return false;
-          },
+       &error](LoadBalancingPolicy::PickResult::Fail* fail_pick) {
+        chand_->data_plane_mu_.AssertHeld();
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+          gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick failed: %s", chand_,
+                  this, fail_pick->status.ToString().c_str());
+        }
+        // If we're shutting down, fail all RPCs.
+        grpc_error_handle disconnect_error = chand_->disconnect_error();
+        if (disconnect_error != GRPC_ERROR_NONE) {
+          MaybeRemoveCallFromLbQueuedCallsLocked();
+          *error = GRPC_ERROR_REF(disconnect_error);
+          return true;
+        }
+        // If wait_for_ready is false, then the error indicates the RPC
+        // attempt's final status.
+        if ((send_initial_metadata_flags &
+             GRPC_INITIAL_METADATA_WAIT_FOR_READY) == 0) {
+          grpc_error_handle lb_error =
+              absl_status_to_grpc_error(fail_pick->status);
+          *error = GRPC_ERROR_CREATE_REFERENCING_FROM_STATIC_STRING(
+              "Failed to pick subchannel", &lb_error, 1);
+          GRPC_ERROR_UNREF(lb_error);
+          MaybeRemoveCallFromLbQueuedCallsLocked();
+          return true;
+        }
+        // If wait_for_ready is true, then queue to retry when we get a new
+        // picker.
+        MaybeAddCallToLbQueuedCallsLocked();
+        return false;
+      },
       // DropPick
-      [this, &error](LoadBalancingPolicy::PickResult::Drop* drop_pick)
-          ABSL_EXCLUSIVE_LOCKS_REQUIRED(&ClientChannel::data_plane_mu_) {
-            if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
-              gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick dropped: %s",
-                      chand_, this, drop_pick->status.ToString().c_str());
-            }
-            *error =
-                grpc_error_set_int(absl_status_to_grpc_error(drop_pick->status),
-                                   GRPC_ERROR_INT_LB_POLICY_DROP, 1);
-            MaybeRemoveCallFromLbQueuedCallsLocked();
-            return true;
-          });
+      [this, &error](LoadBalancingPolicy::PickResult::Drop* drop_pick) {
+        chand_->data_plane_mu_.AssertHeld();
+        if (GRPC_TRACE_FLAG_ENABLED(grpc_client_channel_routing_trace)) {
+          gpr_log(GPR_INFO, "chand=%p lb_call=%p: LB pick dropped: %s", chand_,
+                  this, drop_pick->status.ToString().c_str());
+        }
+        *error =
+            grpc_error_set_int(absl_status_to_grpc_error(drop_pick->status),
+                               GRPC_ERROR_INT_LB_POLICY_DROP, 1);
+        MaybeRemoveCallFromLbQueuedCallsLocked();
+        return true;
+      });
 }
 
 }  // namespace grpc_core


### PR DESCRIPTION
Hey Mark... I made some temporary workarounds... for the Mutex I'm using AssertHeld - there's a small cost, but in the noise compared to the rest. For the WorkQueue, no such fix occurs to me so I'm just disabling annotations for now in that specific clause.

I expect this is generally solvable, but I have no quick fix, so this might need to do for now.